### PR TITLE
Required default_factory for python>3.11

### DIFF
--- a/lcm/datacards/datacards.yaml
+++ b/lcm/datacards/datacards.yaml
@@ -1,8 +1,7 @@
 # FIXME
 name: "pretraining_data"
 parquet_path:
-  #s3: "s3://dl.fbaipublicfiles.com/LCM/rocstories"
-  s3: "/large_experiments/lcm/data/sonarized/rocstories"
+  s3: "wiki_data"
 source_column: "text_sentences_sonar_emb"
 source_text_column: "text_sentences"
 # partition columns:
@@ -11,7 +10,7 @@ source_text_column: "text_sentences"
 # FIXME
 name: "finetuning_data"
 parquet_path:
-  s3: "/large_experiments/lcm/data/sonarized/cosmopedia_sample"
+  s3: "cosmopedia_sample"
 source_column: prompt_sentences_sonar_emb
 source_text_column: prompt_sentences
 target_column: text_sentences_sonar_emb

--- a/lcm/datasets/configs.py
+++ b/lcm/datasets/configs.py
@@ -27,12 +27,12 @@ class ParquetBatchFormat(Enum):
 
 
 class ColumnsNames(Enum):
-    source_column: str = "_source_column"
-    source_text_column: str = "_source_text_column"
-    target_column: str = "_target_column"
-    target_text_column: str = "_target_text_column"
+    source_column = "_source_column"
+    source_text_column = "_source_text_column"
+    target_column = "_target_column"
+    target_text_column = "_target_text_column"
 
-    dataset_name: str = "_dataset_name"
+    dataset_name = "_dataset_name"
 
 
 @dataclass

--- a/lcm/nn/denoisers/factory.py
+++ b/lcm/nn/denoisers/factory.py
@@ -3,7 +3,7 @@
 #
 #
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, Optional
 
 from fairseq2.logging import get_log_writer
@@ -36,10 +36,10 @@ class DenoiserConfig(TransformerConfig):
     pos_embedding_style: Literal["rope", "sine", "learned", "none"] = "none"
     """By default, a denoiser does not have a positional embedder"""
 
-    pre_denoiser: ProjectionConfig = ProjectionConfig()
+    pre_denoiser: ProjectionConfig = field(default_factory=lambda: ProjectionConfig())
     """the initial projection at the top of the denoiser"""
 
-    post_denoiser: ProjectionConfig = ProjectionConfig()
+    post_denoiser: ProjectionConfig = field(default_factory=lambda: ProjectionConfig())
     """the final output projection at the end of the denoiser"""
 
     timestep_embed_dim: int = 1024

--- a/lcm/train/lcm/trainer.py
+++ b/lcm/train/lcm/trainer.py
@@ -47,14 +47,16 @@ class LCMTrainingConfig(TrainingConfig):
     model_config_or_name: Union[AbstractLCModelConfig, str, None] = None
     """The model configuration or name to train."""
 
-    requirements: Requirements = Requirements(
-        nodes=1,
-        tasks_per_node=8,
-        gpus_per_node=8,
-        cpus_per_task=8,
-        mem_gb=256,
-        timeout_min=3 * 24 * 60,
-        constraint="volta32gb",
+    requirements: Requirements = field(
+        default_factory=lambda: Requirements(
+            nodes=1,
+            tasks_per_node=8,
+            gpus_per_node=8,
+            cpus_per_task=8,
+            mem_gb=256,
+            timeout_min=3 * 24 * 60,
+            constraint="volta32gb",
+        )
     )
     """The scheduling requirements for this trainer"""
 

--- a/lcm/train/trainer.py
+++ b/lcm/train/trainer.py
@@ -128,14 +128,16 @@ class TrainingConfig:
     wandb_run_name: Optional[str] = None
     wandb_entity: Optional[str] = None
 
-    requirements: Requirements = Requirements(
-        nodes=1,
-        tasks_per_node=8,
-        gpus_per_node=8,
-        cpus_per_task=8,
-        mem_gb=256,
-        timeout_min=3 * 24 * 60,
-        constraint="volta32gb",
+    requirements: Requirements = field(
+        default_factory=lambda: Requirements(
+            nodes=1,
+            tasks_per_node=8,
+            gpus_per_node=8,
+            cpus_per_task=8,
+            mem_gb=256,
+            timeout_min=3 * 24 * 60,
+            constraint="volta32gb",
+        )
     )
     """The scheduling requirements for this trainer"""
 


### PR DESCRIPTION
Launching a training job with python >= 3.11 throws the error:
```
'Error loading 'lcm.train.lcm.trainer.prepare_lcm_trainer':
ValueError("mutable default <class 'stopes.core.stopes_module.Requirements'> for field requirements is not allowed: use default_factory")
```