### PR TITLE
Fix data schema in example evaluation script

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,4 +8,4 @@ runs:
     - name: "Install libsndfile"
       shell: bash
       run: |
-        sudo apt-get install libsndfile1 setuptools
+        sudo apt-get install libsndfile1

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,4 +8,4 @@ runs:
     - name: "Install libsndfile"
       shell: bash
       run: |
-        sudo apt-get install libsndfile1 python3-distutils
+        sudo apt-get install libsndfile1 setuptools

--- a/examples/evaluation/README.md
+++ b/examples/evaluation/README.md
@@ -21,7 +21,7 @@ Next, we download and parse the content (source text and summaries), saving diff
 ```shell
 python prepare_evaluation_data.py prepare_data \
     --dataset_name=cnn_dailymail \
-    --output_dir=jsonl_dataset/cnn_dailymail \
+    --output_dir=jsonl_dataset \
     --source_text_column=article \
     --target_text_column=highlights \
     --version=3.0.0 \
@@ -41,6 +41,8 @@ To perform sentence splitting and sonar embedding for each split, run the follow
 ```shell
 python prepare_evaluation_data.py embed \
     --input_path=jsonl_dataset/cnn_dailymail/test.jsonl \
+    --input_column=article \
+    --output_column=highlights \
     --output_dir=parquet_dataset/cnn_dailymail \
     --lang=eng_Latn \
     --mode=slurm \
@@ -96,6 +98,8 @@ uv run torchrun --standalone --nnodes=1 --nproc-per-node=1 -m lcm.evaluation \
 ```
 
 In the example above, we load the model "meta-llama/Llama-3.1-8B-Instruct" as [specified](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct) in HuggingFace, evaluate it on the CNN dailymail in which we process using the `prepare_evaluation_data.py` script as in Step 1.1, and store the results in the folder specified via `dump_dir`. The argument `dataset_dir` refers to the value of the argument `output_dir` in Step 1.1.
+
+In some cases, the model requires authentication token to evaluate. You can obtain them in HuggingGface (see [User Access Tokens](https://huggingface.co/docs/hub/en/security-tokens)), then add the parameter `--use_auth_token [YOUR TOKEN]` to the CLI command.
 
 You can also customize the prompt used to evaluate the LLM for each evaluation run. To do this, instead of specifying the `prompt_prefix` and `prompt_suffix` when preparing the data (as shown in the example in Section 1.1), we specify `dataset.source_prefix_text` and `dataset.source_suffix_text` during the evaluation run:
 

--- a/examples/evaluation/prepare_evaluation_data.py
+++ b/examples/evaluation/prepare_evaluation_data.py
@@ -10,9 +10,9 @@
 # be straightforward to apply to other datasets as well.
 #
 
-from dataclasses import dataclass
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional
 

--- a/examples/evaluation/prepare_evaluation_data.py
+++ b/examples/evaluation/prepare_evaluation_data.py
@@ -56,9 +56,8 @@ class SonarColumnRenameAndEmbedConfig(SonarTextEmbedderConfig):
 
 
 class InstSonarEmbedder(SonarTextBatchEmbedder):
-    
     config: SonarColumnRenameAndEmbedConfig
-    
+
     def __init__(self, config: SonarColumnRenameAndEmbedConfig) -> None:
         super().__init__(config)
         self.sat_splitter = SaT("sat-3l")
@@ -130,12 +129,14 @@ class InstSonarEmbedder(SonarTextBatchEmbedder):
     def __call__(self, batch: pa.Table) -> pa.Table:
         batch = batch_to_pandas(batch)
 
-        batch[f"{INPUT_KEY}_sentences"] = self.split_one_single_column(batch[self.config.input_column])
+        batch[f"{INPUT_KEY}_sentences"] = self.split_one_single_column(
+            batch[self.config.input_column]
+        )
         batch[f"{INPUT_KEY}_sentences"] = self.resplit_long_sentences(
             batch[f"{INPUT_KEY}_sentences"],
             max_length_char=256,
         )
-        
+
         if self.config.output_column is not None:
             batch[f"{OUTPUT_KEY}_sentences"] = self.split_one_single_column(
                 batch[self.config.output_column]
@@ -162,7 +163,7 @@ def prepare_data(
 
     prompt_prefix = prompt_prefix or ""
     prompt_suffix = prompt_suffix or ""
-    
+
     # If there is no prompt added to the dataset, we keep the original column names
     if not prompt_prefix and not prompt_suffix:
         source = source_text_column

--- a/examples/evaluation/prepare_evaluation_data.py
+++ b/examples/evaluation/prepare_evaluation_data.py
@@ -159,8 +159,17 @@ def prepare_data(
 ):
     """Download HuggingFace datasets and parse them into JSON format"""
     ds = datasets.load_dataset(dataset_name, version)
+
     prompt_prefix = prompt_prefix or ""
     prompt_suffix = prompt_suffix or ""
+    
+    # If there is no prompt added to the dataset, we keep the original column names
+    if not prompt_prefix and not prompt_suffix:
+        source = source_text_column
+        target = target_text_column
+    else:
+        source = INPUT_KEY
+        target = OUTPUT_KEY
 
     for split in SPLITS:
         with open(
@@ -169,12 +178,12 @@ def prepare_data(
             for item in ds[split]:
                 prompt = prompt_prefix + item[source_text_column] + prompt_suffix
                 output_item = {
-                    source_text_column: prompt,
+                    source: prompt,
                     "split": split,
                     "category": f"{dataset_name}",
                 }
                 if target_text_column is not None:
-                    output_item[target_text_column] = item[target_text_column]
+                    output_item[target] = item[target_text_column]
                 o.write(json.dumps(output_item) + "\n")
 
 

--- a/lcm/evaluation/predictors/gemma.py
+++ b/lcm/evaluation/predictors/gemma.py
@@ -6,7 +6,6 @@
 from dataclasses import dataclass
 
 from lcm.evaluation.api import (
-    GROUND_TRUTH_COLUMN,
     PREDICTION_COLUMN,
     Example,
 )

--- a/lcm/evaluation/predictors/gemma.py
+++ b/lcm/evaluation/predictors/gemma.py
@@ -32,7 +32,7 @@ class GemmaPredictor(HuggingfacePredictor):
     def post_process(self, x: Example) -> Example:
         """Handle the cleaning of response from Gemma models"""
 
-        pred = x[PREDICTION_COLUMN]
+        pred = x.pop(PREDICTION_COLUMN)
 
         # Pretrained model
         if not self.config.model_name.endswith("-it"):
@@ -56,10 +56,7 @@ class GemmaPredictor(HuggingfacePredictor):
                 colon_idx = pred.find(":")
                 pred = pred[colon_idx + 1 :].strip()
 
-        if GROUND_TRUTH_COLUMN in x:
-            return {
-                PREDICTION_COLUMN: pred,
-                GROUND_TRUTH_COLUMN: x[GROUND_TRUTH_COLUMN],
-            }
-        else:
-            return {PREDICTION_COLUMN: pred}
+        return {
+            PREDICTION_COLUMN: pred,
+            **x,
+        }

--- a/lcm/evaluation/tasks/cnn_dailymail.py
+++ b/lcm/evaluation/tasks/cnn_dailymail.py
@@ -59,7 +59,7 @@ def get_task_config_llm(
 
     # Add original columns for judge tasks
     dataset.columns = [dataset.source_text_column, dataset.target_text_column]
-    postprocess_fn = partial(default_text_postprocess, source_text_column=source_text_column)  # fmt: skip
+    postprocess_fn = partial(default_text_postprocess, source_text_column=dataset.source_text_column)  # fmt: skip
 
     return GenerationTaskConfig(
         dataset=dataset,

--- a/lcm/evaluation/tasks/cnn_dailymail.py
+++ b/lcm/evaluation/tasks/cnn_dailymail.py
@@ -58,8 +58,8 @@ def get_task_config_llm(
     dataset.target_text_column = target_text_column
 
     # Add original columns for judge tasks
-    dataset.columns = [source_text_column, target_text_column]
-    postprocess_fn = partial(default_text_postprocess,source_text_column=source_text_column)  # fmt: skip
+    dataset.columns = [dataset.source_text_column, dataset.target_text_column]
+    postprocess_fn = partial(default_text_postprocess, source_text_column=source_text_column)  # fmt: skip
 
     return GenerationTaskConfig(
         dataset=dataset,

--- a/lcm/evaluation/tasks/xsum.py
+++ b/lcm/evaluation/tasks/xsum.py
@@ -55,7 +55,7 @@ def get_task_config_llm(
     dataset.target_text_column = target_text_column
 
     # Add original columns for judge tasks
-    dataset.columns = [source_text_column, target_text_column]
+    dataset.columns = [dataset.source_text_column, dataset.target_text_column]
 
     postprocess_fn = partial(
         default_text_postprocess, source_text_column=source_text_column

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -613,8 +613,6 @@ def default_text_postprocess(
 
     if ColumnsNames.target_text_column.value in x:
         res["targets"] = [x[ColumnsNames.target_text_column.value]]
-    
-    breakpoint()
 
     if source_text_column in x:
         res["source"] = x[source_text_column]

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -150,7 +150,7 @@ def _add_affix(
     if column in inp.keys():
         inp[column] = str(prefix or "") + to_str(inp[column]) + str(suffix or "")
     else:
-        assert orig_column in inp, f"Missing {column} or {orig_column}"
+        assert orig_column in inp, f"Missing {column} or {orig_column} (Found columns: {inp.keys()})"
         inp[column] = str(prefix or "") + to_str(inp[orig_column]) + str(suffix or "")
     return inp
 

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -80,7 +80,7 @@ def renaming_keys(inp: Example, dataset: DatasetConfig) -> Example:
             continue
         if getattr(dataset, att, None):
             mapper[getattr(dataset, att)] = getattr(ColumnsNames, att).value
-
+    breakpoint()
     dcols = dataset.columns
     if isinstance(inp, Dict):
         inp_cols = inp.keys()

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -150,7 +150,9 @@ def _add_affix(
     if column in inp.keys():
         inp[column] = str(prefix or "") + to_str(inp[column]) + str(suffix or "")
     else:
-        assert orig_column in inp, f"Missing {column} or {orig_column} (Found columns: {inp.keys()})"
+        assert orig_column in inp, (
+            f"Missing {column} or {orig_column} (Found columns: {inp.keys()})"
+        )
         inp[column] = str(prefix or "") + to_str(inp[orig_column]) + str(suffix or "")
     return inp
 

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -613,6 +613,8 @@ def default_text_postprocess(
 
     if ColumnsNames.target_text_column.value in x:
         res["targets"] = [x[ColumnsNames.target_text_column.value]]
+    
+    breakpoint()
 
     if source_text_column in x:
         res["source"] = x[source_text_column]

--- a/lcm/evaluation/utils/data_utils.py
+++ b/lcm/evaluation/utils/data_utils.py
@@ -80,7 +80,7 @@ def renaming_keys(inp: Example, dataset: DatasetConfig) -> Example:
             continue
         if getattr(dataset, att, None):
             mapper[getattr(dataset, att)] = getattr(ColumnsNames, att).value
-    breakpoint()
+
     dcols = dataset.columns
     if isinstance(inp, Dict):
         inp_cols = inp.keys()


### PR DESCRIPTION
## Why ?

In example evaluation script ("examples/evaluation/prepare_evaluation_data.py"), the processed datasets are hardcoded with the column schema with new names "prompt", "answer". This was done to make the next data processing steps in LCM evaluation (sentence splitting, sonar embedding) easier, but it was inconsistent in LLM evaluation, because they do not need much data processing and can work directly with original dataset. 

This PR makes the following changes to make the evaluation script more flexible:

- In Step 1 (preparing the JSONL dataset split), if the user specifies "prompt" parameters (`prompt_prefix`, `prompt_suffix`), we rename the columns to "prompt" and "answer".
- If the user does no specify these parameters, the original column names are kept


**NOTE**: There is an issue in Python 3.12 compatibility related to stopes https://github.com/facebookresearch/stopes/pull/71 , which also makes the current CI failed. This PR was tested and passed on Python 3.11
